### PR TITLE
Print errors to stderr.

### DIFF
--- a/bin/homy
+++ b/bin/homy
@@ -17,5 +17,5 @@ installer.install()
     console.log('Symlinks created successfully!');
   })
   .fail(function (error) {
-    console.log(error.message);
+    console.error(error.message);
   });


### PR DESCRIPTION
As described at [node doc](https://nodejs.org/api/console.html#console_console_error_data) and supported by this [post](http://www.jstorimer.com/blogs/workingwithcode/7766119-when-to-use-stderr-instead-of-stdout).

Fix #8.
